### PR TITLE
Update API version in MVC and WebForms demo.

### DIFF
--- a/Demos/MVC/src/AppDomainGenerator/DomainGenerator.cs
+++ b/Demos/MVC/src/AppDomainGenerator/DomainGenerator.cs
@@ -66,7 +66,7 @@ namespace GroupDocs.Annotation.MVC.AppDomainGenerator
         public void SetAnnotationLicense()
         {
             // Initiate license class
-            var obj = (GroupDocs.Annotation.License)Activator.CreateInstance(CurrentType);
+            var obj = (GroupDocs.Annotation.Licenses.License)Activator.CreateInstance(CurrentType);
             // Set license
             SetLicense(obj);
         }        

--- a/Demos/MVC/src/Global.asax.cs
+++ b/Demos/MVC/src/Global.asax.cs
@@ -13,7 +13,7 @@ namespace GroupDocs.Annotation.MVC
             // Set GroupDocs products assemblies names
             string annotationAssemblyName = "GroupDocs.Annotation.dll";
             // set GroupDocs.Annotation license
-            DomainGenerator annotationDomainGenerator = new DomainGenerator(annotationAssemblyName, "GroupDocs.Annotation.License");
+            DomainGenerator annotationDomainGenerator = new DomainGenerator(annotationAssemblyName, "GroupDocs.Annotation.Licenses.License");
             annotationDomainGenerator.SetAnnotationLicense();
            
             AreaRegistration.RegisterAllAreas();

--- a/Demos/MVC/src/GroupDocs.Annotation.MVC.csproj
+++ b/Demos/MVC/src/GroupDocs.Annotation.MVC.csproj
@@ -48,8 +48,8 @@
     <Reference Include="Antlr3.Runtime, Version=3.4.1.9004, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
       <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Annotation, Version=21.2.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Annotation.21.2.0\lib\net20\GroupDocs.Annotation.dll</HintPath>
+    <Reference Include="GroupDocs.Annotation, Version=21.6.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Annotation.21.6.0\lib\net20\GroupDocs.Annotation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/Demos/MVC/src/Products/Annotation/Annotator/BaseAnnotator.cs
+++ b/Demos/MVC/src/Products/Annotation/Annotator/BaseAnnotator.cs
@@ -143,15 +143,18 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Annotator
             {
                 case "Portable Document Format":
                     return AnnotatePdf();
+                case "Microsoft Visio":
                 case "Microsoft Word":
                 case "Open Document Text":
                     return AnnotateWord();
                 case "Rich Text Format":
                     return AnnotateWord();
+                case "Open Document Presentation":
                 case "Microsoft PowerPoint":
                     return AnnotateSlides();
                 case "image":
                     return AnnotateImage();
+                case "Open Document Spreadsheet":
                 case "Microsoft Excel":
                     return AnnotateCells();
                 case "AutoCAD Drawing File Format":

--- a/Demos/MVC/src/Products/Annotation/Annotator/ResourceRedactionAnnotator.cs
+++ b/Demos/MVC/src/Products/Annotation/Annotator/ResourceRedactionAnnotator.cs
@@ -32,7 +32,7 @@ namespace GroupDocs.Annotation.MVC.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateCells()
         {
-            throw new NotSupportedException(string.Format(Message, annotationData.type));
+            return AnnotateWord();
         }
 
         public override AnnotationBase AnnotateSlides()

--- a/Demos/MVC/src/packages.config
+++ b/Demos/MVC/src/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
-  <package id="GroupDocs.Annotation" version="21.2.0" targetFramework="net45" />
+  <package id="GroupDocs.Annotation" version="21.6.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.5" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />

--- a/Demos/WebForms/src/GroupDocs.Annotation.WebForms.csproj
+++ b/Demos/WebForms/src/GroupDocs.Annotation.WebForms.csproj
@@ -44,8 +44,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GroupDocs.Annotation, Version=21.2.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Annotation.21.2.0\lib\net20\GroupDocs.Annotation.dll</HintPath>
+    <Reference Include="GroupDocs.Annotation, Version=21.6.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Annotation.21.6.0\lib\net20\GroupDocs.Annotation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/Demos/WebForms/src/Products/Annotation/Annotator/AreaAnnotator.cs
+++ b/Demos/WebForms/src/Products/Annotation/Annotator/AreaAnnotator.cs
@@ -32,7 +32,7 @@ namespace GroupDocs.Annotation.WebForms.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateCells()
         {
-            throw new NotSupportedException(String.Format(Message, annotationData.type));
+            return AnnotateWord();
         }
 
         public override AnnotationBase AnnotateSlides()

--- a/Demos/WebForms/src/Products/Annotation/Annotator/ArrowAnnotator.cs
+++ b/Demos/WebForms/src/Products/Annotation/Annotator/ArrowAnnotator.cs
@@ -35,7 +35,7 @@ namespace GroupDocs.Annotation.WebForms.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateCells()
         {
-            throw new NotSupportedException(string.Format(Message, annotationData.type));
+            return AnnotateWord();
         }
 
         public override AnnotationBase AnnotateSlides()

--- a/Demos/WebForms/src/Products/Annotation/Annotator/BaseAnnotator.cs
+++ b/Demos/WebForms/src/Products/Annotation/Annotator/BaseAnnotator.cs
@@ -142,15 +142,18 @@ namespace GroupDocs.Annotation.WebForms.Products.Annotation.Annotator
             {
                 case "Portable Document Format":
                     return AnnotatePdf();
+                case "Microsoft Visio":
                 case "Microsoft Word":
                 case "Open Document Text":
                     return AnnotateWord();
                 case "Rich Text Format":
                     return AnnotateWord();
+                case "Open Document Presentation":
                 case "Microsoft PowerPoint":
                     return AnnotateSlides();
                 case "image":
                     return AnnotateImage();
+                case "Open Document Spreadsheet":
                 case "Microsoft Excel":
                     return AnnotateCells();
                 case "AutoCAD Drawing File Format":

--- a/Demos/WebForms/src/Products/Annotation/Annotator/DistanceAnnotator.cs
+++ b/Demos/WebForms/src/Products/Annotation/Annotator/DistanceAnnotator.cs
@@ -33,7 +33,7 @@ namespace GroupDocs.Annotation.WebForms.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateCells()
         {
-            throw new NotSupportedException(string.Format(Message, annotationData.type));
+            return AnnotateWord();
         }
 
         public override AnnotationBase AnnotateSlides()

--- a/Demos/WebForms/src/Products/Annotation/Annotator/PointAnnotator.cs
+++ b/Demos/WebForms/src/Products/Annotation/Annotator/PointAnnotator.cs
@@ -32,7 +32,7 @@ namespace GroupDocs.Annotation.WebForms.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateCells()
         {
-            throw new NotSupportedException(String.Format(Message, annotationData.type));
+            return AnnotateWord();
         }
 
         public override AnnotationBase AnnotateSlides()

--- a/Demos/WebForms/src/Products/Annotation/Annotator/ResourceRedactionAnnotator.cs
+++ b/Demos/WebForms/src/Products/Annotation/Annotator/ResourceRedactionAnnotator.cs
@@ -32,7 +32,7 @@ namespace GroupDocs.Annotation.WebForms.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateCells()
         {
-            throw new NotSupportedException(string.Format(Message, annotationData.type));
+            return AnnotateWord();
         }
 
         public override AnnotationBase AnnotateSlides()

--- a/Demos/WebForms/src/Products/Annotation/Annotator/TextFieldAnnotator.cs
+++ b/Demos/WebForms/src/Products/Annotation/Annotator/TextFieldAnnotator.cs
@@ -36,7 +36,7 @@ namespace GroupDocs.Annotation.WebForms.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateCells()
         {
-            throw new NotSupportedException(string.Format(Message, annotationData.type));
+            return AnnotateWord();
         }
 
         public override AnnotationBase AnnotateSlides()

--- a/Demos/WebForms/src/Products/Annotation/Annotator/TextRedactionAnnotator.cs
+++ b/Demos/WebForms/src/Products/Annotation/Annotator/TextRedactionAnnotator.cs
@@ -21,7 +21,7 @@ namespace GroupDocs.Annotation.WebForms.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateCells()
         {
-            throw new NotSupportedException(string.Format(Message, annotationData.type));
+            return AnnotateWord();
         }
 
         public override AnnotationBase AnnotateSlides()

--- a/Demos/WebForms/src/Products/Annotation/Annotator/TextReplacementAnnotator.cs
+++ b/Demos/WebForms/src/Products/Annotation/Annotator/TextReplacementAnnotator.cs
@@ -33,7 +33,7 @@ namespace GroupDocs.Annotation.WebForms.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateCells()
         {
-            throw new NotSupportedException(string.Format(Message, annotationData.type));
+            return AnnotateWord();
         }
 
         public override AnnotationBase AnnotateSlides()

--- a/Demos/WebForms/src/Products/Annotation/Annotator/TextStrikeoutAnnotator.cs
+++ b/Demos/WebForms/src/Products/Annotation/Annotator/TextStrikeoutAnnotator.cs
@@ -34,7 +34,7 @@ namespace GroupDocs.Annotation.WebForms.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateCells()
         {
-            throw new NotSupportedException(string.Format(Message, annotationData.type));
+            return AnnotateWord();
         }
 
         public override AnnotationBase AnnotateSlides()

--- a/Demos/WebForms/src/Products/Annotation/Annotator/TextUnderlineAnnotator.cs
+++ b/Demos/WebForms/src/Products/Annotation/Annotator/TextUnderlineAnnotator.cs
@@ -33,7 +33,7 @@ namespace GroupDocs.Annotation.WebForms.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateCells()
         {
-            throw new NotSupportedException(String.Format(Message, annotationData.type));
+            return AnnotateWord();
         }
 
         public override AnnotationBase AnnotateSlides()

--- a/Demos/WebForms/src/Products/Annotation/Annotator/WatermarkAnnotator.cs
+++ b/Demos/WebForms/src/Products/Annotation/Annotator/WatermarkAnnotator.cs
@@ -36,7 +36,7 @@ namespace GroupDocs.Annotation.WebForms.Products.Annotation.Annotator
 
         public override AnnotationBase AnnotateCells()
         {
-            throw new NotSupportedException(string.Format(Message, annotationData.type));
+            return AnnotateWord();
         }
 
         public override AnnotationBase AnnotateSlides()

--- a/Demos/WebForms/src/Products/Annotation/Controllers/AnnotationApiController.cs
+++ b/Demos/WebForms/src/Products/Annotation/Controllers/AnnotationApiController.cs
@@ -250,7 +250,7 @@ namespace GroupDocs.Annotation.WebForms.Products.Annotation.Controllers
             List<string> allPages = new List<string>();
 
             //get page HTML
-            for (int i = 0; i < pages.PageCount; i++)
+            for (int i = 0; i < pages.PagesInfo.Count; i++)
             {
                 byte[] bytes;
                 using (var memoryStream = RenderPageToMemoryStream(annotator, i + 1))

--- a/Demos/WebForms/src/packages.config
+++ b/Demos/WebForms/src/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
-  <package id="GroupDocs.Annotation" version="21.2.0" targetFramework="net45" />
+  <package id="GroupDocs.Annotation" version="21.6.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.6" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls.Core" version="1.0.2" targetFramework="net45" />


### PR DESCRIPTION
1. Update Annotation library version to 21.6.0 version in both MVC and WebForms demo-projects.
2. Transfer changes from https://github.com/groupdocs-annotation/GroupDocs.Annotation-for-.NET-WebForms/pull/50.